### PR TITLE
Move template type at the class level

### DIFF
--- a/src/ol/Collection.js
+++ b/src/ol/Collection.js
@@ -56,6 +56,7 @@ export class CollectionEvent extends Event {
  * Collection; they trigger events on the appropriate object, not on the
  * Collection as a whole.
  *
+ * @template T
  * @api
  */
 class Collection extends BaseObject {
@@ -63,7 +64,6 @@ class Collection extends BaseObject {
   /**
    * @param {Array.<T>=} opt_array Array.
    * @param {Options=} opt_options Collection options.
-   * @template T
    */
   constructor(opt_array, opt_options) {
 

--- a/src/ol/structs/LRUCache.js
+++ b/src/ol/structs/LRUCache.js
@@ -16,15 +16,17 @@ import EventType from '../events/EventType.js';
  */
 
 
+/**
+ * Implements a Least-Recently-Used cache where the keys do not conflict with
+ * Object's properties (e.g. 'hasOwnProperty' is not allowed as a key). Expiring
+ * items from the cache is the responsibility of the user.
+ *
+ * @fires import("../events/Event.js").Event
+ * @template T
+ */
 class LRUCache extends EventTarget {
 
   /**
-   * Implements a Least-Recently-Used cache where the keys do not conflict with
-   * Object's properties (e.g. 'hasOwnProperty' is not allowed as a key). Expiring
-   * items from the cache is the responsibility of the user.
-   *
-   * @fires import("../events/Event.js").Event
-   * @template T
    * @param {number=} opt_highWaterMark High water mark.
    */
   constructor(opt_highWaterMark) {

--- a/src/ol/structs/PriorityQueue.js
+++ b/src/ol/structs/PriorityQueue.js
@@ -11,19 +11,22 @@ import {clear} from '../obj.js';
 export const DROP = Infinity;
 
 
+/**
+ * Priority queue.
+ *
+ * The implementation is inspired from the Closure Library's Heap class and
+ * Python's heapq module.
+ *
+ * @see http://closure-library.googlecode.com/svn/docs/closure_goog_structs_heap.js.source.html
+ * @see http://hg.python.org/cpython/file/2.7/Lib/heapq.py
+ *
+ * @template T
+ */
 class PriorityQueue {
+
   /**
-   * Priority queue.
-   *
-   * The implementation is inspired from the Closure Library's Heap class and
-   * Python's heapq module.
-   *
-   * @see http://closure-library.googlecode.com/svn/docs/closure_goog_structs_heap.js.source.html
-   * @see http://hg.python.org/cpython/file/2.7/Lib/heapq.py
-   *
    * @param {function(T): number} priorityFunction Priority function.
    * @param {function(T): string} keyFunction Key function.
-   * @template T
    */
   constructor(priorityFunction, keyFunction) {
 

--- a/src/ol/structs/RBush.js
+++ b/src/ol/structs/RBush.js
@@ -15,14 +15,16 @@ import {isEmpty} from '../obj.js';
  * @property {Object} [value]
  */
 
+/**
+ * Wrapper around the RBush by Vladimir Agafonkin.
+ *
+ * @see https://github.com/mourner/rbush
+ * @template T
+ */
 class RBush {
 
   /**
-   * Wrapper around the RBush by Vladimir Agafonkin.
-   *
    * @param {number=} opt_maxEntries Max entries.
-   * @see https://github.com/mourner/rbush
-   * @template T
    */
   constructor(opt_maxEntries) {
 


### PR DESCRIPTION
This removes the TS1092 error from TypeScript: Type parameters cannot appear on a constructor declaration.
